### PR TITLE
fix: デプロイワークフローの作業ディレクトリを更新

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ jobs:
 
       # ルートで依存関係をインストール（vectorize_articles.js がルートにある場合）
       - name: Install dependencies
+        working-directory: pro
         run: npm ci
 
       # Markdown 記事のベクトル化と DB の upsert／削除処理を実行


### PR DESCRIPTION
- deploy.ymlで依存関係のインストール時に作業ディレクトリを'pro'に設定