### PR TITLE
fix: globのインポート方法を修正

### DIFF
--- a/script/vectorize_articles.mjs
+++ b/script/vectorize_articles.mjs
@@ -1,7 +1,7 @@
 // vectorize_articles.js
 import fs from 'fs';
 import path from 'path';
-import glob from 'glob';
+import { glob } from 'glob';
 import matter from 'gray-matter';
 import fetch from 'node-fetch';
 import crypto from 'crypto';


### PR DESCRIPTION
vectorize_articles.mjsでglobをデフォルトインポートから名前付きインポートに変更しました。