### PR TITLE
fix: ウィジェットのマウント処理をブラウザ環境でのみ実行するよう修正

### DIFF
--- a/pro/src/clientModules/chatWidget.js
+++ b/pro/src/clientModules/chatWidget.js
@@ -3,8 +3,9 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import RagChatWidget from '../components/RagChatWidget';
 
-// ページ全体にウィジェットを追加するための div を作成して body に追加
-const mountNode = document.createElement('div');
-document.body.appendChild(mountNode);
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  const mountNode = document.createElement('div');
+  document.body.appendChild(mountNode);
 
-ReactDOM.render(<RagChatWidget />, mountNode);
+  ReactDOM.render(<RagChatWidget />, mountNode);
+}


### PR DESCRIPTION
chatWidget.jsファイルにおいて、ウィジェットを追加するためのdivを作成し、bodyに追加する処理をブラウザ環境でのみ実行するように変更しました。これにより、サーバーサイドレンダリング時のエラーを防ぎます。