### PR TITLE
fix: generate_candidate_links.jsをgenerate_candidate_links.mjsに変更

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,7 @@ jobs:
       # ビルド成果物に候補リンク用 JSON を生成（generate_candidate_links.js を実行）
       - name: Generate candidate links
         working-directory: pro
-        run: node generate_candidate_links.js
+        run: node generate_candidate_links.mjs
 
       # ビルド成果物をアップロード
       - name: Upload Build Artifact


### PR DESCRIPTION
GitHub Actionsのデプロイワークフローで、候補リンク生成のスクリプトを.jsから.mjsに変更しました。