### PR TITLE
fix: globのインポート方法を修正

### DIFF
--- a/pro/generate_candidate_links.mjs
+++ b/pro/generate_candidate_links.mjs
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { JSDOM } from 'jsdom';
 import { promisify } from 'util';
-import glob from 'glob';
+import { glob } from 'glob';
 
 const globPromise = promisify(glob);
 


### PR DESCRIPTION
generate_candidate_links.mjsファイルにおいて、globのインポートをデフォルトインポートから名前付きインポートに変更しました。