### PR TITLE
feat: GitHub Pagesへのデプロイ設定を更新

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,44 +1,33 @@
-name: Deploy to GitHub Pages
+name: Deploy RAG-enhanced Docusaurus to GitHub Pages
 
 on:
   push:
     branches:
-      - master
+      - main
+  workflow_dispatch:
 
 jobs:
   update-embeddings:
-    name: Update Article Embeddings
+    name: Generate Article Embeddings
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: '20.11.0'
 
-      # pro ディレクトリで依存関係をインストール
-      - name: Install pro dependencies
+      - name: Install dependencies
         working-directory: pro
         run: npm ci
 
-      # script ディレクトリで依存関係をインストール
-      - name: Install script dependencies
-        working-directory: script
-        run: npm ci
-
-      # Markdown 記事のベクトル化と DB の upsert／削除処理を実行（script フォルダ内の vectorize_articles.mjs を実行）
-      - name: Run vectorization script
+      - name: Generate article embeddings
+        working-directory: pro
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           REACT_APP_GEMINI_API_KEY: ${{ secrets.REACT_APP_GEMINI_API_KEY }}
-        working-directory: script
-        run: node vectorize_articles.mjs
+        run: node scripts/vectorize_articles.mjs
 
   build:
     name: Build Docusaurus Site and Generate Candidate Links
@@ -55,22 +44,23 @@ jobs:
         with:
           node-version: '20.11.0'
 
-      # pro ディレクトリで依存関係のインストール
       - name: Install dependencies
         working-directory: pro
         run: npm ci
 
-      # Docusaurus サイトのビルド（pro/build に成果物が出力されるように設定）
+      - name: Inject env vars for frontend
+        working-directory: pro
+        run: |
+          echo "REACT_APP_GEMINI_API_KEY=${{ secrets.REACT_APP_GEMINI_API_KEY }}" > .env
+
       - name: Build Docusaurus site
         working-directory: pro
         run: npm run build
 
-      # ビルド成果物に候補リンク用 JSON を生成（generate_candidate_links.js を実行）
       - name: Generate candidate links
         working-directory: pro
         run: node generate_candidate_links.mjs
 
-      # ビルド成果物をアップロード
       - name: Upload Build Artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -79,14 +69,14 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
+    runs-on: ubuntu-latest
     permissions:
       pages: write
       id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
     steps:
-      - name: Deploy to GitHub Pages
+      - name: Deploy GitHub Pages site
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
- デプロイ名を「Deploy RAG-enhanced Docusaurus to GitHub Pages」に変更
- ブランチ名を「master」から「main」に変更
- ジョブ名を「Update Article Embeddings」から「Generate Article Embeddings」に変更
- 不要な依存関係インストールステップを削除
- 環境変数の設定を追加
- 候補リンク生成スクリプトのファイル名を「generate_candidate_links.js」から「generate_candidate_links.mjs」に変更
- デプロイステップの名前を「Deploy to GitHub Pages」から「Deploy GitHub Pages site」に変更