### PR TITLE
fix: デプロイ設定のブランチ名を'main'から'master'に変更

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy RAG-enhanced Docusaurus to GitHub Pages
 on:
   push:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
.github/workflows/deploy.ymlのpushイベントで使用するブランチ名を'main'から'master'に修正しました。