### PR TITLE
feat: embeddingをJSON形式で保存するように変更

### DIFF
--- a/script/vectorize_articles.mjs
+++ b/script/vectorize_articles.mjs
@@ -30,7 +30,7 @@ async function getEmbedding(text) {
     pooling: 'mean',
     normalize: true,
   });
-  return output.data[0];
+  return output.data[0]; // ← float[] が返る
 }
 
 // Markdown 処理
@@ -65,7 +65,7 @@ async function processMarkdownFiles() {
         file_path: relativePath,
         meta,
         content: cleanedContent,
-        embedding,
+        embedding: JSON.stringify(embedding), // ✅ ← ここが重要！
         hash,
       };
 


### PR DESCRIPTION
- vectorize_articles.mjsのgetEmbedding関数でfloat[]を返すように修正
- processMarkdownFiles関数でembeddingをJSON.stringifyして保存するように変更