### PR TITLE
feat: RagChatコンポーネントでモデルの動的インポートを追加

### DIFF
--- a/pro/src/components/RagChat.jsx
+++ b/pro/src/components/RagChat.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import { pipeline } from '@xenova/transformers';
 
 function RagChat() {
   const [query, setQuery] = useState('');
@@ -17,6 +16,7 @@ function RagChat() {
 
   useEffect(() => {
     async function loadModel() {
+      const { pipeline } = await import('@xenova/transformers');
       const embedder = await pipeline('feature-extraction', 'Xenova/all-MiniLM-L6-v2');
       embedderRef.current = embedder;
       setModelLoaded(true);


### PR DESCRIPTION
RagChatコンポーネント内で、@xenova/transformersからのpipelineを動的にインポートするように変更しました。これにより、モデルの読み込みが効率的になります。