### PR TITLE
fix: baseUrlを'/ootomonaiso_strage/'に変更

### DIFF
--- a/pro/docusaurus.config.js
+++ b/pro/docusaurus.config.js
@@ -6,7 +6,7 @@ const config = {
   tagline: '大友内装(粒)の技術ブログ',
   favicon: 'img/favicon.ico',
   url: 'https://ootomonaiso.github.io',
-  baseUrl: '/',
+  baseUrl: '/ootomonaiso_strage/',
 
   organizationName: 'ootomonaiso',
   projectName: 'ootomonaiso_strage',  


### PR DESCRIPTION
docusaurus.config.jsのbaseUrlを更新し、正しいパスを設定しました。