### PR TITLE
Fix Discord notification URL generation and enhance repository history retrieval

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,14 +115,18 @@ jobs:
           # 新規ページの公開通知
           UPDATED_FILES=$(git diff --name-only HEAD~1 HEAD)
           for FILE in $UPDATED_FILES; do
+            # 'pro/' 部分を削除して正しい URL を作成
+            CLEAN_FILE_PATH=${FILE#pro/}  # 'pro/' を取り除く
+
             # URLの作成
-            PAGE_URL="https://ootomonaiso.github.io/ootomonaiso_strage/$FILE"
+            PAGE_URL="https://ootomonaiso.github.io/ootomonaiso_strage/$CLEAN_FILE_PATH"
             
             # Markdown形式で通知メッセージを作成
-            MESSAGE=":tada: **新しいページが公開されました！** :tada:\n\n[${FILE}](${PAGE_URL})"
+            MESSAGE=":tada: **新しいページが公開されました！** :tada:\n\n[${CLEAN_FILE_PATH}](${PAGE_URL})"
 
             # Discord Webhook で通知
             curl -X POST -H "Content-Type: application/json" \
               -d '{"content": "'"$MESSAGE"'"}' \
               ${{ secrets.DISCORD_WEBHOOK_URL }}
+
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Send Discord Notification
         if: success()
         run: |
+          # リポジトリの履歴をフルに取得
+          git fetch --depth=2  # HEAD~1 を参照できるようにするために履歴を2つ前まで取得
+
           # 新規ページの公開通知
           UPDATED_FILES=$(git diff --name-only HEAD~1 HEAD)
           for FILE in $UPDATED_FILES; do
@@ -128,5 +131,6 @@ jobs:
             curl -X POST -H "Content-Type: application/json" \
               -d '{"content": "'"$MESSAGE"'"}' \
               ${{ secrets.DISCORD_WEBHOOK_URL }}
+
 
 


### PR DESCRIPTION
Correct the URL generation for Discord notifications by removing the 'pro/' prefix and update the notification message to reflect the correct file name. Add functionality to fetch the repository history to ensure notifications include the latest changes.