### PR TITLE
feat: NAT設定のラベルと説明を更新

### DIFF
--- a/pro/NetWork/Cisco_command/Nat/_category_.json
+++ b/pro/NetWork/Cisco_command/Nat/_category_.json
@@ -1,8 +1,8 @@
 {
-  "label": "Ciscoルーターのコマンドと設定のための手順",
+  "label": "NAT設定",
   "position": 3,
   "link": {
     "type": "generated-index",
-    "description": "ルーターに設定するものの手順まとめ"
+    "description": "NAT設定の手順まとめ"
   }
 }


### PR DESCRIPTION
- ラベルを「Ciscoルーターのコマンドと設定のための手順」から「NAT設定」に変更
- 説明を「ルーターに設定するものの手順まとめ」から「NAT設定の手順まとめ」に変更