### PR TITLE
fix: docusaurusConfigのインポートパスを修正

### DIFF
--- a/script/filter-docusaurus-docs.js
+++ b/script/filter-docusaurus-docs.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import docusaurusConfig from '../docusaurus.config.js';
+import docusaurusConfig from '../pro/docusaurus.config.js';
 
 /**
  * git diff --name-status の出力ファイルから、


### PR DESCRIPTION
filter-docusaurus-docs.jsファイル内で、docusaurusConfigのインポートパスを'../docusaurus.config.js'から'../pro/docusaurus.config.js'に変更しました。