### PR TITLE
Devlop

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,7 +151,7 @@ jobs:
         if: success()
         run: |
           SITE_URL="https://ootomonaiso.github.io/ootomonaiso_strage/"
-          MESSAGE=$(echo -e ":tada: **サイトが更新されました！** :tada:\n\n📘 更新されたページ:\n\n${DOC_MSG}\n\n🔗 サイト: <${SITE_URL}>" | jq -Rs .)
+          MESSAGE=$(echo -e ":tada: **サイトが更新されました！** :tada:\n\n 更新されたページ:\n\n${DOC_MSG}\n\n サイト: <${SITE_URL}>" | jq -Rs .)
           curl -X POST -H "Content-Type: application/json" \
             -d "{\"content\": $MESSAGE}" \
             ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
deploy.ymlのDiscord通知メッセージから、リンクの前にある「📘 更新されたページ:」と「🔗 サイト:」の絵文字を削除しました。